### PR TITLE
Buildharness

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+dist: xenial
+language: minimal
+
+os:
+  - linux
+
+env:
+  global:
+  - TERRAFORM_VER="0.11.13"
+  - TF_VAR_deployment="travisci${TRAVIS_JOB_ID}"
+  - TF_VAR_sl_username="${sl_username}"
+  - TF_VAR_sl_api_key="${sl_api_key}"
+  - REG_IMAGE="ibmcom-amd64/icp-inception:3.1.2-ee"
+  matrix:
+    ## Community Edition Builds
+    # CE minimal
+    - TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-minimal"
+      TERRAFORM_VARS_FILE: "${TERRAFORM_DIR}/terraform-minimal-example.tfvars"
+    # CE With loadbalancers
+    - TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-minimal"
+      TERRAFORM_VARS_FILE: "${TERRAFORM_DIR}/terraform-minimal-example.tfvars"
+    # TODO: Add enterprise edition
+
+# Ensure we have ibmcloud terraform provider
+before_install:
+  - mkdir -p ~/.terraform.d/plugins
+  - wget -o /tmp/linux_amd64.zip https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v0.16.1/linux_amd64.zip
+  - unzip /tmp/linux_amd64.zip -d ~/.terraform.d/plugins
+
+# Init the build harness
+before_script:
+  - make init
+
+  # Deploy the environment if changes in the relevant template
+script:
+  - make deploy-icp-if-tfchange
+  - make validate-icp
+
+
+# When everything has completed we can clean up the environment
+after_script:
+  - make cleanup

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ env:
     - TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-minimal"
       TERRAFORM_VARS_FILE: "${TERRAFORM_DIR}/terraform-minimal-example.tfvars"
     # CE With loadbalancers
-    - TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-minimal"
+    - TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-with-loadbalancers"
       TERRAFORM_VARS_FILE: "${TERRAFORM_DIR}/terraform-minimal-example.tfvars"
     # TODO: Add enterprise edition
 
 # Ensure we have ibmcloud terraform provider
 before_install:
   - mkdir -p ~/.terraform.d/plugins
-  - wget -o /tmp/linux_amd64.zip https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v0.16.1/linux_amd64.zip
+  - wget -P /tmp/ https://github.com/IBM-Cloud/terraform-provider-ibm/releases/download/v0.16.1/linux_amd64.zip
   - unzip /tmp/linux_amd64.zip -d ~/.terraform.d/plugins
 
 # Init the build harness

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,16 @@ env:
   - TF_VAR_sl_username="${sl_username}"
   - TF_VAR_sl_api_key="${sl_api_key}"
   - REG_IMAGE="ibmcom-amd64/icp-inception:3.1.2-ee"
+  - ICP_VALIDATION_BRANCH=minimal
   matrix:
     ## Community Edition Builds
     # CE minimal
-    - TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-minimal"
+    - NAME: "CE Minimal"
+      TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-minimal"
       TERRAFORM_VARS_FILE: "${TERRAFORM_DIR}/terraform-minimal-example.tfvars"
     # CE With loadbalancers
-    - TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-with-loadbalancers"
+    - NAME: "CE with loadbalancer"
+      TERRAFORM_DIR: "${TRAVIS_BUILD_DIR}/templates/icp-ce-with-loadbalancers"
       TERRAFORM_VARS_FILE: "${TERRAFORM_DIR}/terraform-minimal-example.tfvars"
     # TODO: Add enterprise edition
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,83 @@
+# Define build harness branch
+BUILD_HARNESS_ORG = hans-moen
+BUILD_HARNESS_BRANCH = hktest
+
+# Define the template and vars file used by the build-harness terraform module
+TERRAFORM_DIR ?=
+TERRAFORM_VARS_FILE ?=
+
+# GITHUB_USER containing '@' char must be escaped with '%40'
+GITHUB_USER := $(shell echo $(GITHUB_USER) | sed 's/@/%40/g')
+GITHUB_TOKEN ?=
+
+# There are many permutations of templates and tfvar example files.
+# Only run the templates that has changes
+DO_DEPLOY ?= $(shell git diff --name-only $(TRAVIS_COMMIT_RANGE) | grep -q -E "$(shell basename $(TERRAFORM_DIR))/(.*.tf)|(.*.tfvars)" && echo yes || echo no)
+
+
+.PHONY: default
+default:: init;
+
+.PHONY: init\:
+init::
+ifndef GITHUB_USER
+	$(info GITHUB_USER not defined)
+	exit -1
+endif
+	$(info Using GITHUB_USER=$(GITHUB_USER))
+ifndef GITHUB_TOKEN
+	$(info GITHUB_TOKEN not defined)
+	exit -1
+endif
+ifndef TERRAFORM_DIR
+	$(info TERRAFORM_DIR not defined)
+	exit -1
+endif
+	$(info Using TERRAFORM_DIR=$(TERRAFORM_DIR))
+ifndef TERRAFORM_VARS_FILE
+	$(info TERRAFORM_VARS_FILE not defined)
+	exit -1
+endif
+	$(info Using TERRAFORM_VARS_FILE=$(TERRAFORM_VARS_FILE))
+
+-include $(shell curl -so .build-harness -H "Authorization: token $(GITHUB_TOKEN)" -H "Accept: application/vnd.github.v3.raw" "https://raw.github.ibm.com/ICP-DevOps/build-harness/master/templates/Makefile.build-harness"; echo .build-harness)
+
+.PHONY: validate-tf
+## Validate a given terraform template directory without deploying
+validate-tf:
+	@$(SELF) -s terraform:validate TERRAFORM_VARS_FILE=$(TERRAFORM_VARS_FILE) TERRAFORM_DIR=$(TERRAFORM_DIR)
+
+.PHONY: deploy-icp-if-tfchange
+deploy-icp-if-tfchange:
+	git diff --name-only $(TRAVIS_COMMIT_RANGE)
+ifeq "$(DO_DEPLOY)" "no"
+	$(info No changes in templates for or example tfvars in $(basename $(TERRAFORM_DIR)), just doing basic syntax validation.)
+	$(SELF) validate-tf
+else
+		$(SELF) deploy-icp
+endif
+
+.PHONY: deploy-icp
+## Deploy a given terraform template directory with a given terraform VARS file
+deploy-icp:
+	@$(SELF) -s terraform:apply TERRAFORM_VARS_FILE=$(TERRAFORM_VARS_FILE) TERRAFORM_DIR=$(TERRAFORM_DIR)
+
+.PHONY: validate-icp
+validate-icp:
+ifeq "$(DO_DEPLOY)" "no"
+	$(info ICP Not deployed, skipping validation tests)
+else ifeq "$(TRAVIS_TEST_RESULT)" "1"
+	$(error Will not run validation on failed deployment)
+else
+	$(info Running validation test)
+	@export SERVER=$(shell $(SELF) -s terraform:output TERRAFORM_OUTPUT_VAR=icp_console_server) ; \
+	export USERNAME=$(shell $(SELF) -s terraform:output TERRAFORM_OUTPUT_VAR=icp_admin_username) ; \
+	export PASSWORD=$(shell $(SELF) -s terraform:output TERRAFORM_OUTPUT_VAR=icp_admin_password) ; \
+	$(SELF) -s validateicp:runall
+endif
+
+
+.PHONY: cleanup
+## Delete the environment
+cleanup:
+	@$(SELF) -s terraform:destroy

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ else ifeq "$(TRAVIS_TEST_RESULT)" "1"
 	$(error Will not run validation on failed deployment)
 else
 	$(info Running validation test)
-	@export SERVER=$(shell $(SELF) -s terraform:output TERRAFORM_OUTPUT_VAR=icp_console_server) ; \
+	@export SERVER=$(shell $(SELF) -s terraform:output TERRAFORM_OUTPUT_VAR=icp_console_host) ; \
 	export USERNAME=$(shell $(SELF) -s terraform:output TERRAFORM_OUTPUT_VAR=icp_admin_username) ; \
 	export PASSWORD=$(shell $(SELF) -s terraform:output TERRAFORM_OUTPUT_VAR=icp_admin_password) ; \
 	$(SELF) -s validateicp:runall

--- a/templates/icp-ce-minimal/icp-deploy.tf
+++ b/templates/icp-ce-minimal/icp-deploy.tf
@@ -51,22 +51,26 @@ module "icpprovision" {
 
 }
 
-output "ICP Console URL" {
+output "icp_console_host" {
+  value = "${element(ibm_compute_vm_instance.icp-master.*.ipv4_address, 0)}"
+}
+
+output "icp_console_url" {
   value = "https://${element(ibm_compute_vm_instance.icp-master.*.ipv4_address, 0)}:8443"
 }
 
-output "ICP Proxy" {
+output "icp_proxy_host" {
   value = "${element(ibm_compute_vm_instance.icp-proxy.*.ipv4_address, 0)}"
 }
 
-output "ICP Kubernetes API URL" {
+output "kubernetes_api_url" {
   value = "https://${element(ibm_compute_vm_instance.icp-master.*.ipv4_address, 0)}:8001"
 }
 
-output "ICP Admin Username" {
+output "icp_admin_username" {
   value = "admin"
 }
 
-output "ICP Admin Password" {
+output "icp_admin_password" {
   value = "${local.icppassword}"
 }

--- a/templates/icp-ce-minimal/terraform-minimal-example.tfvars
+++ b/templates/icp-ce-minimal/terraform-minimal-example.tfvars
@@ -1,0 +1,3 @@
+## The minimum settings needed is username and password
+# sl_username = "softlayer username"
+# sl_api_key = "softlayer api key"

--- a/templates/icp-ce-minimal/terraform-minimal-example.tfvars
+++ b/templates/icp-ce-minimal/terraform-minimal-example.tfvars
@@ -3,4 +3,4 @@
 # sl_api_key = "softlayer api key"
 
 # Datacenter also needs to be set explicitly
-datacenter = "ams06"
+datacenter = "fra05"

--- a/templates/icp-ce-minimal/terraform-minimal-example.tfvars
+++ b/templates/icp-ce-minimal/terraform-minimal-example.tfvars
@@ -1,3 +1,6 @@
 ## The minimum settings needed is username and password
 # sl_username = "softlayer username"
 # sl_api_key = "softlayer api key"
+
+# Datacenter also needs to be set explicitly
+datacenter = "ams06"

--- a/templates/icp-ce-with-loadbalancers/icp-deploy.tf
+++ b/templates/icp-ce-with-loadbalancers/icp-deploy.tf
@@ -53,30 +53,31 @@ module "icpprovision" {
     ssh_agent       = false
 }
 
-output "ICP Console load balancer DNS (external)" {
+
+output "icp_console_host" {
   value = "${ibm_lbaas.master-lbaas.vip}"
 }
 
-output "ICP Proxy load balancer DNS (external)" {
+output "icp_proxy_host" {
   value = "${ibm_lbaas.proxy-lbaas.vip}"
 }
 
-output "ICP Console URL" {
+output "icp_console_url" {
   value = "https://${ibm_lbaas.master-lbaas.vip}:8443"
 }
 
-output "ICP Registry URL" {
+output "icp_registry_url" {
   value = "${ibm_lbaas.master-lbaas.vip}:8500"
 }
 
-output "ICP Kubernetes API URL" {
+output "kubernetes_api_url" {
   value = "https://${ibm_lbaas.master-lbaas.vip}:8001"
 }
 
-output "ICP Admin Username" {
+output "icp_admin_username" {
   value = "admin"
 }
 
-output "ICP Admin Password" {
+output "icp_admin_password" {
   value = "${local.icppassword}"
 }

--- a/templates/icp-ce-with-loadbalancers/security_group.tf
+++ b/templates/icp-ce-with-loadbalancers/security_group.tf
@@ -49,7 +49,8 @@ resource "ibm_security_group_rule" "allow_port_8443" {
   protocol = "tcp"
   port_range_min = 8443
   port_range_max = 8443
-  remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
+  remote_ip = "0.0.0.0/0" # Cloud Loadbalancers seem to sometimes pass own IP, other times pass real source
+  # remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
   security_group_id = "${ibm_security_group.master_group.id}"
 }
 
@@ -60,7 +61,8 @@ resource "ibm_security_group_rule" "allow_port_8500" {
   protocol = "tcp"
   port_range_min = 8500
   port_range_max = 8500
-  remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
+  remote_ip = "0.0.0.0/0" # Cloud Loadbalancers seem to sometimes pass own IP, other times pass real source
+  # remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
   security_group_id = "${ibm_security_group.master_group.id}"
 }
 
@@ -71,7 +73,8 @@ resource "ibm_security_group_rule" "allow_port_8600" {
   protocol = "tcp"
   port_range_min = 8600
   port_range_max = 8600
-  remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
+  remote_ip = "0.0.0.0/0" # Cloud Loadbalancers seem to sometimes pass own IP, other times pass real source
+  # remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
   security_group_id = "${ibm_security_group.master_group.id}"
 }
 
@@ -82,7 +85,8 @@ resource "ibm_security_group_rule" "allow_port_8001" {
   protocol = "tcp"
   port_range_min = 8001
   port_range_max = 8001
-  remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
+  remote_ip = "0.0.0.0/0" # Cloud Loadbalancers seem to sometimes pass own IP, other times pass real source
+  # remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
   security_group_id = "${ibm_security_group.master_group.id}"
 }
 
@@ -94,7 +98,8 @@ resource "ibm_security_group_rule" "allow_port_9443" {
   protocol = "tcp"
   port_range_min = 9443
   port_range_max = 9443
-  remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
+  remote_ip = "0.0.0.0/0" # Cloud Loadbalancers seem to sometimes pass own IP, other times pass real source
+  # remote_ip = "${ibm_compute_vm_instance.icp-master.0.private_subnet}"
   security_group_id = "${ibm_security_group.master_group.id}"
 }
 
@@ -111,7 +116,8 @@ resource "ibm_security_group_rule" "allow_port_80" {
   protocol = "tcp"
   port_range_min = 80
   port_range_max = 80
-  remote_ip = "${ibm_compute_vm_instance.icp-proxy.0.private_subnet}"
+  remote_ip = "0.0.0.0/0" # Cloud Loadbalancers seem to sometimes pass own IP, other times pass real source
+  # remote_ip = "${ibm_compute_vm_instance.icp-proxy.0.private_subnet}"
   security_group_id = "${ibm_security_group.proxy_group.id}"
 }
 
@@ -122,7 +128,8 @@ resource "ibm_security_group_rule" "allow_port_443" {
   protocol = "tcp"
   port_range_min = 443
   port_range_max = 443
-  remote_ip = "${ibm_compute_vm_instance.icp-proxy.0.private_subnet}"
+  remote_ip = "0.0.0.0/0" # Cloud Loadbalancers seem to sometimes pass own IP, other times pass real source
+  # remote_ip = "${ibm_compute_vm_instance.icp-proxy.0.private_subnet}"
   security_group_id = "${ibm_security_group.proxy_group.id}"
 }
 

--- a/templates/icp-ce-with-loadbalancers/terraform-minimal-example.tfvars
+++ b/templates/icp-ce-with-loadbalancers/terraform-minimal-example.tfvars
@@ -1,0 +1,3 @@
+## The minimum settings needed is username and password
+# sl_username = "softlayer username"
+# sl_api_key = "softlayer api key"

--- a/templates/icp-ce-with-loadbalancers/terraform-minimal-example.tfvars
+++ b/templates/icp-ce-with-loadbalancers/terraform-minimal-example.tfvars
@@ -3,4 +3,4 @@
 # sl_api_key = "softlayer api key"
 
 # Datacenter also needs to be set explicitly
-datacenter = "ams06"
+datacenter = "fra05"

--- a/templates/icp-ce-with-loadbalancers/terraform-minimal-example.tfvars
+++ b/templates/icp-ce-with-loadbalancers/terraform-minimal-example.tfvars
@@ -1,3 +1,6 @@
 ## The minimum settings needed is username and password
 # sl_username = "softlayer username"
 # sl_api_key = "softlayer api key"
+
+# Datacenter also needs to be set explicitly
+datacenter = "ams06"

--- a/templates/icp-ee/icp-deploy.tf
+++ b/templates/icp-ee/icp-deploy.tf
@@ -99,30 +99,30 @@ module "icpprovision" {
 
 }
 
-output "ICP Console load balancer DNS (external)" {
+output "icp_console_host" {
   value = "${ibm_lbaas.master-lbaas.vip}"
 }
 
-output "ICP Proxy load balancer DNS (external)" {
+output "icp_proxy_host" {
   value = "${ibm_lbaas.proxy-lbaas.vip}"
 }
 
-output "ICP Console URL" {
+output "icp_console_url" {
   value = "https://${ibm_lbaas.master-lbaas.vip}:8443"
 }
 
-output "ICP Registry URL" {
+output "icp_registry_url" {
   value = "${ibm_lbaas.master-lbaas.vip}:8500"
 }
 
-output "ICP Kubernetes API URL" {
+output "kubernetes_api_url" {
   value = "https://${ibm_lbaas.master-lbaas.vip}:8001"
 }
 
-output "ICP Admin Username" {
+output "icp_admin_username" {
   value = "admin"
 }
 
-output "ICP Admin Password" {
+output "icp_admin_password" {
   value = "${local.icppassword}"
 }


### PR DESCRIPTION
Adds initial support for CI.

Right now only ICP-CE has support, as enterprise edition takes too long to fit into travis job time limit (2 hours for travis enterprise, 50 minutes for travis-ci.com)

Result of this build can be seen here: https://travis.ibm.com/hans-moen/terraform-icp-ibmcloud